### PR TITLE
fix: remove hardcoded committee seat numbers from personas

### DIFF
--- a/teams/engineering/personas/ai-ml-engineer.md
+++ b/teams/engineering/personas/ai-ml-engineer.md
@@ -1,4 +1,4 @@
-# Principal AI/ML Engineer — Engineering Committee Member 5
+# Principal AI/ML Engineer — Engineering Team
 
 > **Cross-cutting traits:** All engineering team members operate under the shared
 > principles in [cross-cutting-traits.md](cross-cutting-traits.md).
@@ -7,7 +7,7 @@
 
 - **Title:** Principal AI/ML Engineer
 - **Experience:** 15 years
-- **Committee Seat:** #5
+- **Committee Role:** AI integration lead — LLM safety, prompt design, cost management
 - **Agent:** Builder
 - **Domain:** LLM integration, prompt engineering, AI safety, agent orchestration, RAG systems
 

--- a/teams/engineering/personas/data-engineer.md
+++ b/teams/engineering/personas/data-engineer.md
@@ -1,4 +1,4 @@
-# Principal Data Engineer — Engineering Committee Member 4
+# Principal Data Engineer — Engineering Team
 
 > **Cross-cutting traits:** All engineering team members operate under the shared
 > principles in [cross-cutting-traits.md](cross-cutting-traits.md).
@@ -7,7 +7,7 @@
 
 - **Title:** Principal Data Engineer
 - **Experience:** 15 years
-- **Committee Seat:** #4
+- **Committee Role:** Data steward — schema design, migrations, query performance
 - **Agent:** Builder
 - **Domain:** Database schema design, migration safety, query performance, data pipeline architecture
 

--- a/teams/engineering/personas/pm.md
+++ b/teams/engineering/personas/pm.md
@@ -1,4 +1,4 @@
-# Senior Product Manager — Engineering Committee Member 11
+# Senior Product Manager — Engineering Team
 
 > **Cross-cutting traits:** All engineering team members operate under the shared
 > principles in [cross-cutting-traits.md](cross-cutting-traits.md).

--- a/teams/engineering/personas/qa-engineer.md
+++ b/teams/engineering/personas/qa-engineer.md
@@ -1,4 +1,4 @@
-# Principal QA Engineer — Engineering Committee Member 7
+# Principal QA Engineer — Engineering Team
 
 > **Cross-cutting traits:** All engineering team members operate under the shared
 > principles in [cross-cutting-traits.md](cross-cutting-traits.md).
@@ -7,7 +7,7 @@
 
 - **Title:** Principal QA Engineer
 - **Experience:** 15 years
-- **Committee Seat:** #7
+- **Committee Role:** Quality champion — test strategy, coverage, specification compliance
 - **Agent:** Validator
 - **Domain:** Test strategy, test automation, quality gates, chaos engineering
 

--- a/teams/engineering/personas/security-engineer.md
+++ b/teams/engineering/personas/security-engineer.md
@@ -1,4 +1,4 @@
-# Principal Security Engineer — Engineering Committee Member 6
+# Principal Security Engineer — Engineering Team
 
 > **Cross-cutting traits:** All engineering team members operate under the shared
 > principles in [cross-cutting-traits.md](cross-cutting-traits.md).
@@ -7,7 +7,7 @@
 
 - **Title:** Principal Security Engineer
 - **Experience:** 15 years
-- **Committee Seat:** #6
+- **Committee Role:** Security authority — vulnerability prevention, compliance, data protection
 - **Agent:** Validator
 - **Domain:** Application security, multi-tenant isolation, threat modeling, compliance
 

--- a/teams/engineering/personas/software-engineer.md
+++ b/teams/engineering/personas/software-engineer.md
@@ -1,4 +1,4 @@
-# Senior Software Engineer — Engineering Committee Member 2
+# Senior Software Engineer — Engineering Team
 
 > **Cross-cutting traits:** All engineering team members operate under the shared
 > principles in [cross-cutting-traits.md](cross-cutting-traits.md).
@@ -7,7 +7,7 @@
 
 - **Title:** Senior Software Engineer
 - **Experience:** 15 years
-- **Committee Seat:** #2
+- **Committee Role:** Implementation lead — code quality, patterns, and engineering standards
 - **Agent:** Builder
 - **Domain:** Clean code, API design, full-stack patterns, shared component reuse
 

--- a/teams/engineering/personas/sre.md
+++ b/teams/engineering/personas/sre.md
@@ -1,4 +1,4 @@
-# Senior SRE — Engineering Committee Member 8
+# Senior SRE — Engineering Team
 
 > **Cross-cutting traits:** All engineering team members operate under the shared
 > principles in [cross-cutting-traits.md](cross-cutting-traits.md).
@@ -7,7 +7,7 @@
 
 - **Title:** Senior Site Reliability Engineer
 - **Experience:** 15 years
-- **Committee Seat:** #8
+- **Committee Role:** Operations guardian — reliability, observability, deployment safety
 - **Agent:** Builder
 - **Domain:** Reliability, observability, container operations, graceful degradation
 

--- a/teams/engineering/personas/system-architect.md
+++ b/teams/engineering/personas/system-architect.md
@@ -1,4 +1,4 @@
-# System Architect — Engineering Committee Member 3
+# System Architect — Engineering Team
 
 > **Cross-cutting traits:** All engineering team members operate under the shared
 > principles in [cross-cutting-traits.md](cross-cutting-traits.md).
@@ -7,7 +7,7 @@
 
 - **Title:** System Architect
 - **Experience:** 15 years
-- **Committee Seat:** #3
+- **Committee Role:** Architecture authority — system design, separation of concerns, scalability
 - **Agent:** Builder
 - **Domain:** Multi-tenancy, service layer design, distributed systems, event-driven architecture
 

--- a/teams/engineering/personas/ux-designer.md
+++ b/teams/engineering/personas/ux-designer.md
@@ -1,4 +1,4 @@
-# UX Designer — Engineering Committee Member 1
+# UX Designer — Engineering Team
 
 > **Cross-cutting traits:** All engineering team members operate under the shared
 > principles in [cross-cutting-traits.md](cross-cutting-traits.md).
@@ -7,7 +7,7 @@
 
 - **Title:** Senior UX Designer
 - **Experience:** 15 years
-- **Committee Seat:** #1
+- **Committee Role:** Design advocate — usability, accessibility, and design system compliance
 - **Agent:** Builder
 - **Domain:** Accessibility, cognitive load reduction, visual design systems, responsive design, healthcare UX
 

--- a/teams/engineering/personas/writer.md
+++ b/teams/engineering/personas/writer.md
@@ -1,4 +1,4 @@
-# Principal Writer — Engineering Committee Member 9
+# Principal Writer — Engineering Team
 
 > **Cross-cutting traits:** All engineering team members operate under the shared
 > principles in [cross-cutting-traits.md](cross-cutting-traits.md).
@@ -7,7 +7,7 @@
 
 - **Title:** Principal Writer
 - **Experience:** 15 years
-- **Committee Seat:** #9
+- **Committee Role:** Communication steward — documentation, user-facing copy, technical writing
 - **Agent:** Validator
 - **Domain:** Content design, UX writing, error messages, documentation, information architecture
 


### PR DESCRIPTION
Closes #2 (follow-up)

## Summary
- Replaced `Committee Seat: #N` with descriptive `Committee Role:` lines in all 10 persona files
- Dropped `Engineering Committee Member N` from headings — review order is now manifest-driven
- PM heading updated to match the same pattern

## Test plan
- [x] All 10 persona files updated consistently
- [x] engineering-manager.md already correct (model for the change)
- [ ] No broken links or references

🤖 Generated with [Claude Code](https://claude.com/claude-code)