### PR TITLE
docs: add newcomer guide with visual diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,117 @@
 # Engineering Directives
 
-How I build software. Personas, processes, and templates for multi-agent software development.
+A manifest-driven system for multi-agent software development. Personas give AI agents depth. Pipelines give them structure. Splitting builder and validator agents gives them independence.
 
-This repo is the canonical source for engineering practices that apply across all projects. Individual project repos reference these directives and add their own project-specific context.
+## The Problem
+
+AI coding assistants are powerful — but when one model builds, reviews, and deploys its own code, it creates correlated failures. The model that wrote a SQL query won't notice it's injectable during review. The model that chose an architecture won't question it during code review. Same blind spots in every phase.
+
+## The Solution
+
+```mermaid
+graph LR
+    subgraph "Builder Agent"
+        B1[Implements code]
+        B2[Runs tests]
+        B3[Deploys]
+    end
+
+    subgraph "Validator Agent"
+        V1[Reviews code]
+        V2[Audits security]
+        V3[Writes specs]
+    end
+
+    B1 -->|"PR + artifacts"| V1
+    V1 -->|"MUST-FIX / SHOULD-FIX / NIT"| B1
+
+    style B1 fill:#0075ca,color:#fff
+    style B2 fill:#0075ca,color:#fff
+    style B3 fill:#0075ca,color:#fff
+    style V1 fill:#6f42c1,color:#fff
+    style V2 fill:#6f42c1,color:#fff
+    style V3 fill:#6f42c1,color:#fff
+```
+
+Split the work across two independent AI agent types. Give each agent **personas** — detailed character profiles that shape how it thinks about UX, security, architecture, testing, and more. Connect everything through a **pipeline** that ensures nothing gets skipped.
+
+**New here? Start with the [guide](#guide).**
+
+---
+
+## How It Works
+
+A GitHub issue flows through six pipeline stages, each producing artifacts the next stage consumes:
+
+```mermaid
+graph LR
+    A["Product Review<br/><code>/pm</code><br/><small>Validator writes PRD</small>"] --> B["Design Review<br/><code>/design</code><br/><small>Committee reviews</small>"]
+    B --> C["Implementation<br/><code>/implement</code><br/><small>TDD: tests first</small>"]
+    C --> D["Code Review<br/><code>/ramd</code><br/><small>Up to 3 rounds</small>"]
+    D --> E["Deploy & Verify<br/><small>Health check</small>"]
+    E --> F["Summarize<br/><code>/summarize</code><br/><small>Stakeholder report</small>"]
+
+    style A fill:#6f42c1,color:#fff
+    style B fill:#0e8a16,color:#fff
+    style C fill:#fbca04,color:#000
+    style D fill:#6e5494,color:#fff
+    style E fill:#0075ca,color:#fff
+    style F fill:#d4c5f9,color:#000
+```
+
+At each review stage, the full engineering committee — 11 personas, each with a distinct professional background and review lens — evaluates the work sequentially, building on each other's feedback:
+
+```
+  UX Designer ──> Software Eng ──> Architect ──> Data Eng ──> AI/ML Eng
+       |               |              |             |            |
+       v               v              v             v            v
+  accessibility    code quality    coupling     migrations    LLM safety
+  design system    patterns        scalability  query perf    prompt risks
+                                                                 |
+  Security Eng ──> QA Engineer ──> SRE ──> Writer ──> Eng Manager
+       |               |           |         |            |
+       v               v           v         v            v
+  vulnerabilities  test coverage  ops     user-facing   synthesizes
+  auth bypass      edge cases     health  copy/docs     all feedback
+  data exposure    test layers    logs    errors        makes final call
+```
+
+---
+
+## Guide
+
+New to this repo? Read these in order:
+
+| Doc | What you'll learn | Time |
+|-----|-------------------|------|
+| [**Key Concepts**](docs/guide/concepts.md) | Agent types, personas, pipeline, committee, manifests — all the terminology | 10 min |
+| [**Why This Architecture?**](docs/guide/why.md) | The problems this solves and the thinking behind each design decision | 10 min |
+| [**Getting Started**](docs/guide/getting-started.md) | Three levels of adoption: personas only, pipeline, or full multi-agent setup | 15 min |
+
+---
 
 ## Architecture
 
 Three config files drive the entire system:
+
+```
+  agents.yml                 manifest.yml               CONTRIBUTING.md
+  (global)                   (per-team)                 (per-project)
+  +------------------+      +------------------+       +------------------+
+  | Agent types      |      | Role roster      |       | Team reference   |
+  | LLM providers    | <--- | Pipeline stages  | <--- | Pipeline mode    |
+  | Assignments      |      | Vocabularies     |       | Provider overrides|
+  | Fallback chains  |      | Settings         |       |                  |
+  +------------------+      +------------------+       +------------------+
+```
 
 | File | Scope | What it controls |
 |------|-------|-----------------|
 | [`agents.yml`](agents.yml) | Global | Agent types, LLM providers, default assignments, fallback chains |
 | [`teams/engineering/manifest.yml`](teams/engineering/manifest.yml) | Per-team | Role roster, pipeline stages, labels, controlled vocabularies |
 | Per-project `CONTRIBUTING.md` | Per-project | Team reference, pipeline mode, provider overrides |
+
+---
 
 ## Teams
 
@@ -48,9 +147,11 @@ Shared culture: [`cross-cutting-traits.md`](teams/engineering/personas/cross-cut
 | [`test-budget.md`](teams/engineering/process/test-budget.md) | Test layer decision framework |
 | [`prd-template.md`](teams/engineering/process/prd-template.md) | Product requirements document format |
 
-## Adding a New Team
+### Adding a New Team
 
 Copy `teams/TEMPLATE/` to `teams/<your-team-name>/` and customize the manifest, personas, and cross-cutting traits. See the [template manifest](teams/TEMPLATE/manifest.yml) for field documentation.
+
+---
 
 ## Global Process
 
@@ -62,6 +163,8 @@ Applies across all teams.
 | [`process/orchestration.md`](process/orchestration.md) | How orchestrators consume config files to route work |
 | [`process/reasoning-framework.md`](process/reasoning-framework.md) | AI reasoning loop, task modes, complexity triggers, review checklist |
 | [`process/safety.md`](process/safety.md) | Universal safety guardrails |
+
+---
 
 ## Templates
 
@@ -75,6 +178,8 @@ Starter files for new project repos:
 | [`worklog.md.template`](templates/worklog.md.template) | Multi-agent coordination log |
 | [`pm-context.md.template`](templates/pm-context.md.template) | Domain context for PM persona |
 
+---
+
 ## Domain Overlays
 
 Optional additions for domain-specific projects:
@@ -83,14 +188,31 @@ Optional additions for domain-specific projects:
 |---------|-------------|
 | [`overlays/healthcare/`](overlays/healthcare/) | HIPAA, PHI handling, patient safety |
 
-## How to Use
-
-1. **New project?** Copy files from `templates/` into your repo and customize.
-2. **Reference personas** from your project's team docs — link, don't copy.
-3. **Apply overlays** relevant to your domain (e.g., healthcare adds HIPAA requirements).
-4. **Keep project-specific content in the project repo** — tech stack, architecture, test accounts, design system.
+---
 
 ## Three-Tier Model
+
+```
++--------------------------------------------------+
+|  Tier 1: Directives (this repo)                  |
+|  Engineering philosophy, personas, process,       |
+|  templates. Shared across ALL projects.           |
++--------------------------------------------------+
+          |
+          v
++--------------------------------------------------+
+|  Tier 2: Organization (optional)                  |
+|  Domain compliance, org-specific workflows,       |
+|  shared CI.                                       |
++--------------------------------------------------+
+          |
+          v
++--------------------------------------------------+
+|  Tier 3: Project                                  |
+|  Tech stack, architecture, environment config.    |
+|  Specific to ONE repo.                            |
++--------------------------------------------------+
+```
 
 | Tier | Where | What |
 |------|-------|------|

--- a/docs/guide/concepts.md
+++ b/docs/guide/concepts.md
@@ -1,0 +1,289 @@
+# Key Concepts
+
+A plain-language guide to the ideas behind this system. Read this first if you're new.
+
+---
+
+## The Core Idea
+
+Most AI coding setups use a single model for everything: writing code, reviewing it, testing it, deploying it. This is like having the same person build a bridge and inspect it — they'll miss the same things both times.
+
+This system fixes that by splitting the work across **agent types**, giving each agent **personas** that shape how it thinks, and connecting everything through a **pipeline** that ensures nothing gets skipped.
+
+```
+  You open a         AI agents review,       Code is built        Independent agents      Deployed and
+  GitHub issue  -->  plan, and design   -->  test-first      -->  review the code    -->  verified
+                     the solution            in isolation          for blind spots
+```
+
+---
+
+## Agent Types
+
+An **agent type** is an abstract role — it describes *what kind of work* gets done, not *which AI model* does it.
+
+```
+                    +-----------+
+                    | agents.yml |  <-- defines these
+                    +-----+-----+
+                          |
+              +-----------+-----------+
+              |                       |
+        +-----+------+        +------+-----+
+        |   Builder   |        |  Validator  |
+        +-----+------+        +------+-----+
+              |                       |
+     Implements code           Reviews code
+     Runs tests                Writes specs
+     Deploys                   Audits security
+     Merges PRs                Files issues
+```
+
+**Builder** and **Validator** are the two agent types. The key insight: the model that *builds* the code should not be the same model that *validates* it.
+
+### Why two agent types?
+
+| Single agent | Two agent types |
+|---|---|
+| Builds code, then reviews its own work | One builds, a different one reviews |
+| Shares blind spots across both tasks | Independent perspectives catch more issues |
+| "Looks good to me" (because I wrote it) | "Wait, did you consider...?" |
+
+### Provider assignment
+
+Agent types are backed by **LLM providers** (Claude Code, Gemini CLI, etc.). The mapping is configured in [`agents.yml`](../../agents.yml):
+
+```yaml
+# Default: Claude builds, Gemini validates
+assignments:
+  default:
+    builder: claude-code
+    validator: gemini-cli
+```
+
+If a provider isn't available, the system falls back — even running both agent types on the same provider in **isolated sessions** so they can't share context.
+
+---
+
+## Personas
+
+A **persona** is a detailed character profile that shapes how an AI agent approaches a specific kind of work. Each persona has a title, years of experience, a professional backstory, core expertise, and a defined review focus.
+
+```
+                         +------------------+
+                         |   Engineering    |
+                         |     Team         |
+                         +--------+---------+
+                                  |
+        +-------+-------+--------+--------+-------+-------+
+        |       |       |        |        |       |       |
+      +---+   +---+   +---+   +----+   +---+   +---+   +---+
+      | UX |   | SE |   | SA |   | DE |   |AI/ML|  |SecE|   | QA |  ...
+      +---+   +---+   +---+   +----+   +---+   +---+   +---+
+```
+
+There are 11 personas on the engineering team, each seeing problems through a different lens:
+
+| Persona | What they care about |
+|---|---|
+| **UX Designer** | Accessibility, design systems, responsive behavior |
+| **Software Engineer** | Code quality, patterns, readability |
+| **System Architect** | Service boundaries, coupling, scalability |
+| **Data Engineer** | Schema design, migrations, query performance |
+| **AI/ML Engineer** | LLM integration, prompt safety, cost |
+| **Security Engineer** | Vulnerabilities, auth, data exposure |
+| **QA Engineer** | Test coverage, edge cases, test layer decisions |
+| **SRE** | Reliability, logging, health checks, degradation |
+| **Writer** | User-facing copy, error messages, documentation |
+| **Engineering Manager** | Synthesizes all feedback, resolves conflicts, makes final calls |
+| **PM** | Requirements, acceptance criteria, user value |
+
+### Why personas matter
+
+Without personas, an AI review comment is generic: "Consider adding error handling." With a persona, the **Security Engineer** says: "This endpoint accepts user input without validation — an attacker could inject SQL via the `name` parameter. MUST-FIX." The persona brings *depth* and *specificity* that generic prompting can't match.
+
+### Cross-cutting traits
+
+Beyond individual expertise, all personas share a team culture defined in [`cross-cutting-traits.md`](../../teams/engineering/personas/cross-cutting-traits.md) — values like radical pragmatism, test-first thinking, and "you carry the pager" ops ownership.
+
+---
+
+## The Pipeline
+
+The **pipeline** is a six-stage workflow that takes a GitHub issue from idea to production. Each stage produces artifacts the next stage consumes, and GitHub labels track progress.
+
+```mermaid
+graph LR
+    A["1. Product Review<br/><code>/pm</code>"] --> B["2. Design Review<br/><code>/design</code>"]
+    B --> C["3. Implementation<br/><code>/implement</code>"]
+    C --> D["4. Code Review & Merge<br/><code>/ramd</code>"]
+    D --> E["5. Deploy & Verify"]
+    E --> F["6. Summarize<br/><code>/summarize</code>"]
+
+    style A fill:#6f42c1,color:#fff
+    style B fill:#0e8a16,color:#fff
+    style C fill:#fbca04,color:#000
+    style D fill:#6e5494,color:#fff
+    style E fill:#0075ca,color:#fff
+    style F fill:#d4c5f9,color:#000
+```
+
+| Stage | What happens | Who does it | Label applied |
+|---|---|---|---|
+| Product Review | PM writes a PRD with acceptance criteria | Validator | `pm-reviewed` |
+| Design Review | Full committee reviews feasibility, architecture, UX, security | Builder + Validator | `design-complete` |
+| Implementation | TDD: write failing tests, implement, get green, refactor | Builder | `implementing` |
+| Code Review & Merge | Up to 3 rounds of committee code review, then squash merge | Builder + Validator | `merged` |
+| Deploy & Verify | Rebuild, health check, close issue | Builder | Issue closed |
+| Summarize | Plain-language summary for stakeholders | Validator | `summarized` |
+
+### Pipeline modes
+
+Projects declare a pipeline mode in their `CONTRIBUTING.md`:
+
+| Mode | Behavior |
+|---|---|
+| **Autonomous** | Runs end-to-end without human gates. For trusted automation and solo AI work. |
+| **Gated** | Pauses after design review and after code review for human authorization. For teams with human contributors. |
+
+---
+
+## The Committee
+
+The **engineering committee** is the full team of personas convening to review an issue or a PR. It's not a meeting — it's a structured, sequential review protocol.
+
+```
+  Issue arrives
+       |
+       v
+  +--[UX Designer]--+
+  |  reviews first   |
+  +--------+---------+
+           |  reads prior comments
+           v
+  +--[Software Eng]--+
+  |  reviews second   |
+  +--------+----------+
+           |  reads prior comments
+           v
+         ...  (each persona in order)
+           |
+           v
+  +--[Writer]--------+
+  |  reviews ninth    |
+  +--------+----------+
+           |
+           v
+  +--[Eng Manager]---+
+  |  synthesizes all  |
+  |  makes final call |
+  +--------+----------+
+           |
+           v
+  Overwrite-to-consensus
+  (members update their
+   comments to reflect
+   final positions)
+           |
+           v
+  Fresh-eyes validation
+  (zero-context sub-agent
+   checks for gaps)
+```
+
+### Key rules
+
+1. **Sequential posting** — Each persona reads *all* prior comments before posting. No parallel reviews. This builds cumulative insight.
+2. **Overwrite-to-consensus** — After the Engineering Manager synthesizes, members whose positions changed edit their original comments. A reader sees clean final positions, not a debate thread.
+3. **Fresh-eyes validation** — A separate sub-agent with zero prior context reads the final issue description and flags anything ambiguous. This catches "curse of knowledge" gaps.
+
+---
+
+## Manifests
+
+A **manifest** is a YAML file that serves as the single source of truth for a team's configuration: who's on the team, what the pipeline looks like, and what vocabulary the team uses.
+
+```yaml
+# teams/engineering/manifest.yml (simplified)
+team: engineering
+
+roles:
+  - id: ux-designer
+    name: UX Designer
+    agent: builder           # <-- which agent type
+    persona: personas/ux-designer.md
+    review_order: 1          # <-- position in committee sequence
+
+pipeline:
+  - stage: pm-review
+    command: /pm
+    agent: validator
+    label:
+      name: pm-reviewed
+      color: "6f42c1"
+
+vocabularies:
+  severity_levels:
+    - id: must-fix
+      blocks: merge
+```
+
+When you change the manifest, the change cascades everywhere — add a new persona, reorder the review sequence, add a pipeline stage, or adjust severity levels in one place.
+
+---
+
+## Severity Levels
+
+Review findings are tagged with a severity that determines whether they block progress:
+
+| Severity | Meaning | Blocks? |
+|---|---|---|
+| **MUST-FIX** | Correctness bug, security vulnerability, data loss risk | Blocks merge |
+| **SHOULD-FIX** | Code quality issue, missing edge case, poor naming | Blocks current review round |
+| **NIT** | Style preference, minor suggestion | Does not block |
+
+---
+
+## The Three-Tier Model
+
+Configuration lives at three levels. Each tier adds specificity without duplicating what the tier above provides.
+
+```
++--------------------------------------------------+
+|  Tier 1: Directives (this repo)                  |
+|  Engineering philosophy, personas, process,       |
+|  templates. Applies to ALL projects.              |
++--------------------------------------------------+
+          |
+          v
++--------------------------------------------------+
+|  Tier 2: Organization                             |
+|  Domain compliance, org-specific workflows,       |
+|  shared CI. (Optional — for orgs with multiple    |
+|  repos.)                                          |
++--------------------------------------------------+
+          |
+          v
++--------------------------------------------------+
+|  Tier 3: Project                                  |
+|  Tech stack, architecture, test accounts,         |
+|  environment config. Specific to ONE repo.        |
++--------------------------------------------------+
+```
+
+The directives repo provides the *what* and *why*. The project repo provides the *how* and *where*. This separation means your engineering practices don't drift between projects.
+
+---
+
+## Domain Overlays
+
+An **overlay** is an optional set of additional rules for domain-specific concerns. For example, a healthcare overlay adds HIPAA compliance, PHI handling rules, and patient safety checks on top of the base engineering process.
+
+Overlays are additive — they extend the base system without replacing it.
+
+---
+
+## Next Steps
+
+- [Why This Architecture?](why.md) — The philosophy behind these decisions
+- [Getting Started](getting-started.md) — Set this up in your own project

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -1,0 +1,287 @@
+# Getting Started
+
+Set up this system in your own project. You can adopt the full pipeline or start with just the pieces that help you most.
+
+---
+
+## Prerequisites
+
+- A GitHub repository for your project
+- At least one AI coding tool (Claude Code, Gemini CLI, Cursor, etc.)
+- Familiarity with the [key concepts](concepts.md)
+
+---
+
+## Quick Start: Three Levels of Adoption
+
+Pick the level that fits your needs. You can always move up later.
+
+```
+  Level 1                Level 2                Level 3
+  Personas Only    -->   + Pipeline       -->   + Multi-Agent
+  (easiest)              (structured)           (full system)
+
+  Use persona lenses     Add the 6-stage        Split builder/validator
+  for better AI          workflow with           across different LLM
+  code reviews           labels and gates        providers
+```
+
+---
+
+## Level 1: Persona-Driven Reviews (15 minutes)
+
+The fastest way to get value. Use the persona definitions to improve your AI code reviews — no config files, no pipeline, no multi-agent setup.
+
+### Step 1: Pick the personas you need
+
+Browse [`teams/engineering/personas/`](../../teams/engineering/personas/). You don't need all 11. Start with the ones that match your biggest gaps:
+
+| If you're worried about... | Use this persona |
+|---|---|
+| Accessibility, design consistency | UX Designer |
+| Code quality, patterns | Software Engineer |
+| Architecture, coupling | System Architect |
+| Database, migrations | Data Engineer |
+| AI/LLM integration | AI/ML Engineer |
+| Security vulnerabilities | Security Engineer |
+| Test coverage, edge cases | QA Engineer |
+| Operational reliability | SRE |
+| User-facing copy, docs | Writer |
+
+### Step 2: Reference them in your AI prompts
+
+When asking your AI tool to review code, reference the persona:
+
+```
+Review this PR as the Security Engineer described in:
+https://github.com/suniljames/directives/blob/main/teams/engineering/personas/security-engineer.md
+
+Categorize findings as MUST-FIX, SHOULD-FIX, or NIT.
+```
+
+That's it. You're already getting more targeted reviews than "review this code for issues."
+
+---
+
+## Level 2: Pipeline + Personas (30 minutes)
+
+Add the structured workflow. This gives you labels, stage gates, and a repeatable process.
+
+### Step 1: Copy the templates
+
+```bash
+# From the directives repo, copy templates into your project
+cp templates/CONTRIBUTING.md.template  your-project/CONTRIBUTING.md
+cp templates/CLAUDE.md.template        your-project/CLAUDE.md
+```
+
+### Step 2: Customize CONTRIBUTING.md
+
+Edit the team and pipeline mode declarations:
+
+```markdown
+<!-- team: engineering -->
+<!-- pipeline-mode: autonomous -->
+```
+
+Choose your pipeline mode:
+- **autonomous** — AI runs the full pipeline without stopping (good for solo AI work)
+- **gated** — AI pauses after design review and code review for your approval (good when you want to stay in the loop)
+
+### Step 3: Fill in the project-specific sections
+
+The templates have `TODO` markers. Fill in your tech stack, dev environment setup, and project docs.
+
+### Step 4: Create slash commands
+
+Create `.claude/commands/` (or equivalent for your AI tool) with commands that map to pipeline stages:
+
+```
+.claude/commands/
+  pm.md         # /pm — Product review
+  design.md     # /design — Committee design review
+  implement.md  # /implement — TDD implementation
+  ramd.md       # /ramd — Review, approve, merge, deploy
+  summarize.md  # /summarize — Stakeholder summary
+```
+
+Each command file tells the AI what to do at that stage. See the [pipeline docs](../../teams/engineering/process/pipeline.md) for what each stage produces.
+
+### Step 5: Set up labels
+
+Create the GitHub labels that track pipeline progress:
+
+```bash
+gh label create "pm-reviewed"     --color "6f42c1" --repo your-org/your-repo
+gh label create "design-complete" --color "0e8a16" --repo your-org/your-repo
+gh label create "implementing"    --color "fbca04" --repo your-org/your-repo
+gh label create "merged"          --color "6e5494" --repo your-org/your-repo
+gh label create "summarized"      --color "d4c5f9" --repo your-org/your-repo
+gh label create "ai:autonomous"   --color "1d76db" --repo your-org/your-repo
+```
+
+### What the flow looks like
+
+```mermaid
+sequenceDiagram
+    participant You
+    participant AI as AI Agent
+    participant GH as GitHub
+
+    You->>GH: Create issue
+    You->>AI: /pm 42
+    AI->>GH: Post PRD comment
+    AI->>GH: Add pm-reviewed label
+    You->>AI: /design 42
+    AI->>GH: Post committee reviews (sequential)
+    AI->>GH: Add design-complete label
+    You->>AI: /implement 42
+    AI->>AI: Write failing tests first
+    AI->>AI: Implement until green
+    AI->>GH: Push feature branch
+    You->>AI: /ramd
+    AI->>GH: Create PR, run code review
+    AI->>GH: Squash merge, add merged label
+    AI->>GH: Close issue
+```
+
+---
+
+## Level 3: Multi-Agent Setup (1 hour)
+
+Split builder and validator across different LLM providers for genuinely independent reviews.
+
+### Step 1: Configure agents.yml
+
+If you're forking or referencing this repo, the default [`agents.yml`](../../agents.yml) maps Claude Code as builder and Gemini CLI as validator. Adjust for your providers:
+
+```yaml
+assignments:
+  default:
+    builder: claude-code      # Your primary coding AI
+    validator: gemini-cli     # Your review/audit AI
+```
+
+### Step 2: Add validator agent config
+
+Create a config file for the validator agent in your project (e.g., `GEMINI.md`):
+
+```markdown
+# Validator Agent Config
+
+You are the **validator** agent. You did NOT build this code.
+Review independently using the personas assigned to you.
+
+Refer to the [engineering directives](https://github.com/suniljames/directives)
+for persona definitions and review process.
+```
+
+### Step 3: Assign roles to agent types
+
+The manifest already does this — each role has an `agent:` field:
+
+```yaml
+roles:
+  - id: security-engineer
+    agent: validator        # Runs on the validator (Gemini)
+  - id: software-engineer
+    agent: builder          # Runs on the builder (Claude)
+```
+
+Builder personas run on the builder agent. Validator personas run on the validator agent. During committee reviews, the orchestrator (or you manually) routes each persona's review to the right agent.
+
+### Step 4: Single-provider fallback
+
+If you only have one AI tool, the system still works. Run both agent types in **separate sessions**:
+
+```
+Session 1 (Builder):
+  "You are the builder agent. Implement the feature."
+
+Session 2 (Validator — separate conversation):
+  "You are the validator agent. You did NOT build this code.
+   Review it independently."
+```
+
+The key: **never share conversation history** between the two sessions.
+
+---
+
+## Customizing Personas
+
+### Adding a new persona
+
+1. Create a markdown file in `teams/engineering/personas/your-role.md` following the [template](../../teams/TEMPLATE/personas/example-role.md)
+2. Add the role to `teams/engineering/manifest.yml`
+3. Persona files include: Identity, Background, Core Expertise, Review Focus, Interaction Style
+
+### Modifying review order
+
+Edit `review_order` in the manifest. The committee reviews in ascending order, with the Engineering Manager always last (`review_order: last`).
+
+### Creating a new team
+
+Copy `teams/TEMPLATE/` to `teams/your-team/` and customize. See the [template manifest](../../teams/TEMPLATE/manifest.yml) for field documentation.
+
+---
+
+## Adding Domain Overlays
+
+If your project has domain-specific requirements (healthcare, fintech, etc.), add an overlay:
+
+```
+overlays/
+  healthcare/        # HIPAA, PHI handling, patient safety
+  your-domain/       # Your domain-specific rules
+```
+
+Overlays are additive — they extend the base process without replacing it. Reference them from your project's `CONTRIBUTING.md`.
+
+---
+
+## Project Structure After Setup
+
+```
+your-project/
+  CONTRIBUTING.md           # Team, pipeline mode, tech stack
+  CLAUDE.md                 # Builder agent config
+  GEMINI.md                 # Validator agent config (optional)
+  .claude/
+    commands/
+      pm.md                 # /pm command
+      design.md             # /design command
+      implement.md          # /implement command
+      ramd.md               # /ramd command
+      summarize.md          # /summarize command
+  docs/
+    developer/
+      code-review-lenses.md # Tech-specific review checklists
+      project-context.md    # Project-specific persona knowledge
+```
+
+The project repo contains project-specific content. The directives repo (this repo) contains the shared engineering practices. Link, don't copy.
+
+---
+
+## Troubleshooting
+
+### "My AI doesn't follow the persona well"
+
+Make sure you're providing the full persona file, not just the role name. The backstory and interaction style matter — they anchor the AI's decision-making.
+
+### "The pipeline feels heavy for small changes"
+
+Use the ad-hoc work gate. The pipeline warns you when you skip stages, but it doesn't block you. For quick fixes, skip straight to implementation and acknowledge the warning.
+
+### "I only have one AI tool"
+
+That's fine — see the single-provider fallback in Level 3. The persona-driven reviews (Level 1) work with any single AI tool.
+
+---
+
+## Next Steps
+
+- [Key Concepts](concepts.md) — Reference for all terminology
+- [Why This Architecture?](why.md) — The philosophy behind these decisions
+- [Pipeline details](../../teams/engineering/process/pipeline.md) — Deep dive into each stage
+- [Committee process](../../teams/engineering/process/committee-process.md) — How the review protocol works

--- a/docs/guide/why.md
+++ b/docs/guide/why.md
@@ -1,0 +1,226 @@
+# Why This Architecture?
+
+The thinking behind the system. Read this if you want to understand *why* the pieces exist, not just *what* they do.
+
+---
+
+## The Problem: AI Agents Are Powerful but Unreliable Alone
+
+AI coding assistants can write, test, deploy, and document software. But when a single model does all of that, it creates **correlated failure modes**:
+
+```
+                Single AI Agent
+                      |
+          +-----------+-----------+
+          |           |           |
+       Builds      Reviews     Deploys
+       the code    the code    the code
+          |           |           |
+          +-----+-----+-----+----+
+                |           |
+         Same blind spots   Same assumptions
+         in ALL phases      in ALL phases
+```
+
+The model that wrote a SQL query won't notice it's injectable during review — it just wrote it that way on purpose. The model that chose an architecture won't question it during code review — it already decided this was the right approach. This is the AI equivalent of grading your own homework.
+
+---
+
+## Solution 1: Split the Builder and the Validator
+
+The first insight: **the model that builds should not be the model that validates.**
+
+```
+     Builder Agent                    Validator Agent
+     (Claude Code)                    (Gemini CLI)
+          |                                |
+    Implements code                  Reviews code
+    Runs tests                       Audits security
+    Deploys                          Writes specs
+          |                                |
+          +---------- Handoff via ----------+
+                    GitHub Issues,
+                    PRs, Labels
+```
+
+This isn't about which AI is "better." It's about **independence**. Two different models trained on different data, with different architectures and different biases, will catch different things. The overlap in what they miss is smaller than what either misses alone.
+
+### What if you only have one provider?
+
+The system handles this gracefully. When only one LLM provider is available, it runs both agent types in **isolated sessions** — separate conversations with no shared context. The validator session is explicitly primed: "You did NOT build this code. Review it independently."
+
+Is this as good as two different models? No. But it's significantly better than a single session that builds and reviews in the same conversation.
+
+---
+
+## Solution 2: Personas Create Depth That Generic Prompting Can't
+
+The second insight: **telling an AI to "review this code" produces shallow feedback. Telling it to review as a specific persona produces deep, targeted feedback.**
+
+Compare:
+
+| Generic prompt | Persona-driven prompt |
+|---|---|
+| "Review this PR for issues" | The Security Engineer reviews through their lens: injection vectors, auth bypass, data exposure, CSRF, multi-tenant leakage |
+| Surface-level observations | Deep domain expertise applied systematically |
+| "Looks good, maybe add some tests" | "MUST-FIX: This endpoint accepts user input at line 47 without sanitization. An attacker could inject SQL via the `name` parameter." |
+
+Each persona has:
+
+- **A backstory** — Not for flavor, but to anchor the AI's decision-making. A Security Engineer "who spent 8 years doing red-team penetration testing at CrowdStrike" reviews differently than a generic "security reviewer."
+- **Core expertise** — What they're qualified to evaluate.
+- **A review lens** — The specific checklist of things they look for.
+- **An interaction style** — How they communicate findings (direct, diplomatic, etc.).
+
+### Why 11 personas?
+
+Because software engineering is genuinely multi-disciplinary. A feature that's architecturally sound might be inaccessible. Code that passes all tests might have a SQL injection vulnerability. A deployment that works might have no health checks.
+
+```
+                        A single PR
+                             |
+     +-------+-------+------+------+-------+-------+
+     |       |       |      |      |       |       |
+    UX    Code    Arch    Data   Security  QA    SRE   ...
+   a11y  quality  coupling perf  vulns    tests  ops
+   design patterns  scale  index  auth   edges  logs
+   motion  DRY    tenant  migrate CSRF  mocks  health
+```
+
+No single reviewer — human or AI — can hold all of these lenses simultaneously. The persona system makes them explicit and systematic.
+
+---
+
+## Solution 3: A Pipeline Prevents Skipping Steps
+
+The third insight: **without a defined workflow, AI agents (like humans) will skip steps under pressure.**
+
+The pipeline enforces a sequence:
+
+```mermaid
+graph TD
+    A["GitHub Issue<br/>Created"] --> B{"PM Review<br/><code>/pm</code>"}
+    B -->|"PRD + acceptance<br/>criteria posted"| C{"Design Review<br/><code>/design</code>"}
+    C -->|"Committee reviews<br/>issue in order"| D{"Implementation<br/><code>/implement</code>"}
+    D -->|"TDD: failing tests<br/>first, then code"| E{"Code Review<br/><code>/ramd</code>"}
+    E -->|"Up to 3 rounds<br/>of review"| F{"Deploy & Verify"}
+    F -->|"Health check<br/>passes"| G["Issue Closed"]
+
+    style A fill:#333,color:#fff
+    style B fill:#6f42c1,color:#fff
+    style C fill:#0e8a16,color:#fff
+    style D fill:#fbca04,color:#000
+    style E fill:#6e5494,color:#fff
+    style F fill:#0075ca,color:#fff
+    style G fill:#333,color:#fff
+```
+
+Each stage:
+- Has a **label** (`pm-reviewed`, `design-complete`, etc.) that tracks completion
+- **Checks** for the previous stage's label before proceeding
+- **Produces artifacts** the next stage consumes (PRD, test spec, code, review comments)
+
+If you skip the PM review and jump to implementation, the system warns you. You can override it (it's advisory, not a hard block), but you have to make a conscious choice.
+
+### Why labels instead of a database?
+
+Because the source of truth should live where the work lives — GitHub. Labels are visible, inspectable, and don't require any additional infrastructure. An orchestrator can read them. A human can read them. Either can advance the pipeline.
+
+---
+
+## Solution 4: Manifests Make the System Configurable
+
+The fourth insight: **hardcoding personas, pipeline stages, and review order in documentation creates maintenance debt that compounds across projects.**
+
+Instead, three config files drive everything:
+
+```
+  agents.yml                 manifest.yml               CONTRIBUTING.md
+  (global)                   (per-team)                 (per-project)
+  +------------------+      +------------------+       +------------------+
+  | Agent types      |      | Role roster      |       | Team reference   |
+  | LLM providers    | <--- | Pipeline stages  | <--- | Pipeline mode    |
+  | Assignments      |      | Vocabularies     |       | Provider overrides|
+  | Fallback chains  |      | Settings         |       |                  |
+  +------------------+      +------------------+       +------------------+
+```
+
+Want to add a new persona? Add a role to the manifest. Change the review order? Edit one number. Swap the LLM provider? Update one line in `agents.yml`. Add a new pipeline stage? One block in the manifest. All downstream consumers automatically pick up the change.
+
+### Why three files instead of one?
+
+Because the three files have different **scopes** and change at different **rates**:
+
+- `agents.yml` changes when you add a new LLM provider (rare)
+- `manifest.yml` changes when you adjust the team or process (occasional)
+- `CONTRIBUTING.md` changes when a specific project needs a different mode (per-project)
+
+Separating them means a project-specific override doesn't require editing global configuration.
+
+---
+
+## Solution 5: Fresh-Eyes Validation Catches What Committees Miss
+
+The fifth insight: **committee members build shared context during review. This context doesn't always make it into the final issue description.**
+
+```
+  Committee reviews issue
+  (9 members + Engineering Manager)
+         |
+         v
+  Rich shared context built
+  through sequential discussion
+         |
+         v
+  Issue description updated
+  with final plan
+         |
+         v
+  But did ALL the context        <-- This is the gap
+  make it into the description?
+         |
+         v
+  Fresh-eyes sub-agent reads
+  ONLY the description
+  (zero prior context)
+         |
+         v
+  Flags gaps: "What does 'the
+  existing pattern' mean here?
+  I don't see it defined."
+```
+
+This is inspired by Anthropic's [doc-coauthoring skill](https://github.com/anthropics/skills/tree/main/skills/doc-coauthoring) "Reader Testing" pattern. A zero-context agent simulates the experience of the developer who will actually implement the work, catching assumptions that feel obvious to the committee but aren't captured in the spec.
+
+---
+
+## Design Principles
+
+These principles guided every architectural decision:
+
+### 1. Decouple roles from providers
+
+Personas are abstract. "Security Engineer" doesn't mean "Gemini." It means "the agent type that reviews for security." This lets you swap LLM providers without rewriting your process.
+
+### 2. The repo is the source of truth
+
+All coordination happens through files, PRs, issues, labels, and comments. No side channels, no databases, no shared state outside Git. Any orchestrator — or a human — can participate.
+
+### 3. Advisory gates, not hard blocks
+
+The pipeline warns you when you skip stages. It doesn't prevent you. This respects the reality that sometimes you need to ship a hotfix without a full committee review.
+
+### 4. Configuration over convention
+
+Don't make people read documentation to figure out the review order or pipeline stages. Put it in a machine-readable manifest that both humans and orchestrators can consume.
+
+### 5. Additive domain overlays
+
+Healthcare needs HIPAA. Fintech needs PCI. These are *additions* to the base process, not replacements. The overlay pattern keeps domain rules separate from engineering fundamentals.
+
+---
+
+## Next Steps
+
+- [Key Concepts](concepts.md) — Quick reference for all the terminology
+- [Getting Started](getting-started.md) — Set this up in your own project


### PR DESCRIPTION
## Summary
- **README rewrite**: Added problem statement, solution overview, Mermaid pipeline diagram, builder/validator flow, committee review visualization. Kept all existing reference tables below the new intro.
- **docs/guide/concepts.md**: Plain-language definitions of agent types, personas, pipeline, committee, manifests, severity levels, three-tier model, and domain overlays. Heavy use of ASCII and Mermaid diagrams.
- **docs/guide/why.md**: Philosophy document explaining the five core design decisions (builder/validator split, personas for depth, pipeline for structure, manifests for configurability, fresh-eyes validation). Each section has a diagram showing the problem and solution.
- **docs/guide/getting-started.md**: Three levels of adoption — Level 1 (personas only, 15 min), Level 2 (pipeline + personas, 30 min), Level 3 (full multi-agent, 1 hour). Includes Mermaid sequence diagram, project structure example, and troubleshooting.

## Test plan
- [x] All internal links verified
- [x] Mermaid diagrams render on GitHub
- [x] Existing README reference content preserved
- [ ] Read through as a newcomer — does it make sense?

🤖 Generated with [Claude Code](https://claude.com/claude-code)