### PR TITLE
fix: remove numbered section headers from code-review-framework

### DIFF
--- a/teams/engineering/process/code-review-framework.md
+++ b/teams/engineering/process/code-review-framework.md
@@ -14,7 +14,7 @@ Each engineering committee member reviews the PR diff through a role-specific le
 
 Each project provides its own technology-specific review checklists. Below is the generic focus area for each role.
 
-### 1. UX Designer
+### UX Designer
 **Skip if:** No frontend files in the diff.
 - Accessibility compliance (contrast, alt text, ARIA, focus management)
 - Semantic HTML, form UX, tab order, keyboard navigation
@@ -22,52 +22,52 @@ Each project provides its own technology-specific review checklists. Below is th
 - Design system compliance (component library tokens, no hardcoded values)
 - Visual hierarchy, motion with reduced-motion respect
 
-### 2. Software Engineer
+### Software Engineer
 - Code quality: DRY, dead code, complexity
 - Naming clarity, readability (functions under 30 lines)
 - API framework patterns: schema validation, dependency injection, proper status codes
 - Frontend patterns: server vs client rendering, proper data fetching
 - Edge cases: empty inputs, null handling, error states
 
-### 3. System Architect
+### System Architect
 - Service layer separation (routing -> business logic -> data access)
 - Multi-tenancy enforcement, tenant context propagation
 - Coupling and cohesion, circular dependencies
 - Frontend routing patterns: layouts, error boundaries
 
-### 4. Data Engineer
+### Data Engineer
 - Migration safety: reversible, separate data from schema migrations
 - Query performance: N+1, missing indexes, eager loading
 - ORM patterns: relationships, async sessions, transaction boundaries
 - Data isolation policy correctness
 
-### 5. AI/ML Engineer
+### AI/ML Engineer
 **Skip if:** No AI/LLM code in the diff.
 - API integration: retry logic, timeout handling, cost tracking
 - Prompt injection risks, sensitive data in prompts
 - Fallback behavior when AI service unavailable
 - Token/cost management
 
-### 6. Security Engineer
+### Security Engineer
 - Injection vectors (SQL, XSS, template injection)
 - Auth bypass: missing middleware, role checks
 - Sensitive data exposure in logs, errors, URLs, API responses
 - CSRF, secret handling, input validation
 - Multi-tenant data leakage
 
-### 7. QA Engineer
+### QA Engineer
 - Test coverage for changed/added code
 - Edge cases, assertion quality, fixture adequacy
 - Test isolation, mock boundaries
 - Correct test layer per test budget (cheapest layer that gives confidence)
 
-### 8. SRE
+### SRE
 - Error handling: graceful degradation for external services
 - Structured logging with context
 - Health checks, container resource usage
 - Connection handling: timeouts, pool awareness
 
-### 9. Writer
+### Writer
 - User-facing copy: helpful errors, clear labels
 - API response messages: clear, no sensitive data
 - Code comments: explain *why*, not *what*


### PR DESCRIPTION
## Summary
- Dropped `### 1.` through `### 9.` prefixes from role section headers in `code-review-framework.md`
- Review order is now manifest-driven — matches the same change already applied to COREcare's `code-review-lenses.md`

## Test plan
- [x] All 9 section headers updated consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)