### PR TITLE
docs: bidirectional builder/validator role swap on provider unavailability

### DIFF
--- a/agents.yml
+++ b/agents.yml
@@ -45,7 +45,14 @@ providers:
 
 # Default: which provider backs each agent type.
 # Orchestrators use this unless the project overrides.
-# fallback_order: if preferred provider is unavailable, try the next.
+#
+# fallback_order: if the preferred provider is unavailable, use the next one.
+# "Unavailable" is not just a missing binary — it includes rate-limiting
+# (HTTP 429) and credit/quota exhaustion. When one provider becomes unavailable,
+# the other assumes the open role (bidirectional role swap): Claude Code can act
+# as validator when Gemini is rate-limited, and Gemini can act as builder when
+# Claude is out of credits. See framework/agent-architecture.md →
+# "Role Swap on Provider Unavailability".
 assignments:
   default:
     builder: claude-code
@@ -53,6 +60,19 @@ assignments:
   fallback_order:
     builder:
       - claude-code
+      - gemini-cli
     validator:
       - gemini-cli
       - claude-code
+
+# Model selection is intentionally NOT pinned here.
+#   - Builder model: whatever the active CLI session is configured to use, set
+#     natively (Claude Code `/model`; Gemini `gemini -m <model>`). Whoever you
+#     launch is the builder, so its model is already chosen by how you start it.
+#   - Validator model: designated per session by the builder when it invokes the
+#     validator bridge, so it can be a smaller/cheaper read-only model:
+#       * Gemini-as-validator → GEMINI_MODEL env var read by the project's
+#         validator wrapper (default gemini-2.5-flash-lite — rate-limit headroom).
+#       * Claude-as-validator → the model of the /code-review session (or
+#         `claude -p --model <model>`) the builder spawns.
+# Pinning concrete values here would drift from the CLIs that actually own them.

--- a/framework/agent-architecture.md
+++ b/framework/agent-architecture.md
@@ -18,7 +18,18 @@ Split roles across abstract **agent types** — a **builder** and a **validator*
 
 ## Provider Assignment
 
-Default assignments and fallback chains are in `agents.yml`. When the preferred provider is unavailable, the system falls back to the next provider in the chain.
+Default assignments and fallback chains are in `agents.yml`. When the preferred provider is unavailable, the system falls back to the next provider in the chain. **"Unavailable" includes rate-limiting (HTTP 429) and credit/quota exhaustion — not just a missing binary.** This is the common trigger in practice: a provider that is installed and working can still be temporarily unusable.
+
+### Role Swap on Provider Unavailability
+
+The default assignment (builder ↔ validator → provider) is a *preference*, not a fixed identity. The roles are **bidirectional**: either provider can play either role, and the mapping swaps when a provider becomes unavailable.
+
+- **Default (Scenario 1):** Claude Code = builder, Gemini = validator.
+- **Swapped (Scenario 2):** Gemini = builder, Claude Code = validator — e.g. when Claude is out of credits, or when the operator simply launches a Gemini session to build.
+
+The operative rule for whichever tool is running: **if your counterpart provider is rate-limited or out of credits, assume the open role.** A builder with no available validator runs the validator pass itself (in an isolated session, below); a tool launched to build when the usual builder is unavailable *is* the builder. Neither role goes unfilled because one provider is down.
+
+In practice the launched CLI determines the builder: start Gemini and Gemini builds; start Claude Code and Claude builds. The validator is then the *other* provider, invoked as a bridge (see model designation in [`agents.yml`](../agents.yml)) — or, if that provider is also unavailable, the same provider in a fresh isolated session.
 
 ### Single-Provider Fallback
 

--- a/framework/orchestration.md
+++ b/framework/orchestration.md
@@ -39,6 +39,8 @@ For each agent_type in agents.yml.agent_types:
 4. If no provider available: skip this agent type (warn the user)
 ```
 
+**"Unavailable" includes rate-limiting (HTTP 429) and credit/quota exhaustion**, not just a missing binary. A provider that returns 429 mid-run, or whose account is out of credits, should be treated as unavailable so the resolver falls through to the next provider in the chain. Because the chains are symmetric (`agents.yml`), this is what lets a builder-default provider be resolved into the validator role (and vice versa) when its counterpart is down — the bidirectional role swap described in [`agent-architecture.md`](agent-architecture.md).
+
 ### Single-Provider Mode
 
 When the same provider backs both agent types (fallback scenario), the orchestrator must:

--- a/templates/CLAUDE.md.template
+++ b/templates/CLAUDE.md.template
@@ -1,6 +1,8 @@
 # <Project Name> — Claude Code Agent Config
 
-Read [`CONTRIBUTING.md`](CONTRIBUTING.md) first.
+By default you are the **builder** agent. Read [`CONTRIBUTING.md`](CONTRIBUTING.md) first.
+
+> **Role is not fixed.** Builder is the default mapping in [`agents.yml`](https://github.com/suniljames/directives/blob/main/agents.yml). If Gemini (the default validator) is unavailable — rate-limited or out of credits — assume the **validator** role per the `fallback_order` in `agents.yml`: run an independent review in an isolated session ("You did NOT create this work"), e.g. via `/code-review --comment`. See [agent-architecture.md → Role Swap](https://github.com/suniljames/directives/blob/main/framework/agent-architecture.md).
 
 Project-specific docs:
 - `docs/developer/ARCHITECTURE.md` — codebase patterns

--- a/templates/GEMINI.md.template
+++ b/templates/GEMINI.md.template
@@ -1,6 +1,8 @@
 # <Project Name> — Gemini Agent Config
 
-You are the **validator** agent. Read [`CONTRIBUTING.md`](CONTRIBUTING.md) first, then the [engineering directives](https://github.com/suniljames/directives).
+By default you are the **validator** agent. Read [`CONTRIBUTING.md`](CONTRIBUTING.md) first, then the [engineering directives](https://github.com/suniljames/directives).
+
+> **Role is not fixed.** Validator is the default mapping in [`agents.yml`](https://github.com/suniljames/directives/blob/main/agents.yml). If Claude Code (the default builder) is unavailable — rate-limited or out of credits — assume the **builder** role per the `fallback_order` in `agents.yml`. Whichever role you hold, follow that role's section below.
 
 Project-specific docs:
 - `docs/developer/ARCHITECTURE.md` — codebase patterns
@@ -13,7 +15,9 @@ Project-specific docs:
 
 ## Your Roles
 
-You are the **validator** agent. Your roles are defined in the [engineering team manifest](https://github.com/suniljames/directives/blob/main/teams/engineering/manifest.yml) — all roles where `agent: validator`.
+### As validator (default)
+
+Your roles are defined in the [engineering team manifest](https://github.com/suniljames/directives/blob/main/teams/engineering/manifest.yml) — all roles where `agent: validator`.
 
 Read each persona file to understand your responsibilities:
 - [Security Engineer](https://github.com/suniljames/directives/blob/main/teams/engineering/personas/security-engineer.md)
@@ -23,13 +27,21 @@ Read each persona file to understand your responsibilities:
 
 Roles you do NOT own (builder agent's): all roles where `agent: builder` in the manifest. File findings; don't fix.
 
+### As builder (swap mode — Claude Code unavailable)
+
+When you have assumed the builder role per `agents.yml` `fallback_order`, you own the roles where `agent: builder` and you create/implement/publish. Run the validator pass in a separate, isolated session with explicit independence priming ("You did NOT create this work"), or hand it to Claude Code if it becomes available. See [agent-architecture.md → Role Swap](https://github.com/suniljames/directives/blob/main/framework/agent-architecture.md).
+
 ## What You Produce
 
 See the [pipeline stages](https://github.com/suniljames/directives/blob/main/teams/engineering/manifest.yml) for your responsibilities at each stage. Use severity levels from the manifest's `vocabularies.severity_levels` when posting review findings.
 
 ## What NOT to Do
 
+**As validator (default):**
 - Do not write production code.
 - Do not merge PRs.
 - Do not deploy.
 - Do not perform roles you don't own.
+
+**Always (either role):**
+- Do not perform builder *and* validator work in the same session — keep the create/review boundary clean across isolated sessions.


### PR DESCRIPTION
## Summary
The default mapping (Claude=builder, Gemini=validator) is a preference, not a fixed identity. Make the swap explicit so whichever tool is running assumes the open role when its counterpart is rate-limited or out of credits.

- **agents.yml** — add `gemini-cli` to `fallback_order.builder` (was `claude-code` only) so the swap is symmetric; document that "unavailable" includes HTTP 429 / credit exhaustion; add the model-designation convention (builder model = native CLI config; validator model = designated per session, not pinned here).
- **framework/agent-architecture.md** — new "Role Swap on Provider Unavailability" subsection (bidirectional, not just degraded single-provider mode).
- **framework/orchestration.md** — provider resolution treats 429 / credit exhaustion as unavailable.
- **templates/{GEMINI,CLAUDE}.md.template** — soften the hardcoded role declarations to "default X; assume the open role if your counterpart is unavailable, per agents.yml".

## Companion PR
Project-side docs + the per-session validator-model (`GEMINI_MODEL`) knob land in `hcunanan79/COREcare-access` (PR #1915).

## Test plan
- [ ] Docs/config-only change; YAML in `agents.yml` parses
- [ ] Cross-references resolve (agent-architecture ↔ orchestration ↔ agents.yml)