### PR TITLE
feat(#31): migrate Gemini CLI → Antigravity CLI (agy)

### DIFF
--- a/agents.yml
+++ b/agents.yml
@@ -34,9 +34,9 @@ providers:
       - tool_use
       - delivery
 
-  - id: gemini-cli
-    name: Gemini CLI
-    binary: gemini
+  - id: antigravity-cli
+    name: Antigravity CLI
+    binary: agy
     strengths:
       - analysis
       - review
@@ -49,10 +49,10 @@ providers:
 assignments:
   default:
     builder: claude-code
-    validator: gemini-cli
+    validator: antigravity-cli
   fallback_order:
     builder:
       - claude-code
     validator:
-      - gemini-cli
+      - antigravity-cli
       - claude-code

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -47,14 +47,14 @@ An **[agent type](glossary.md)** describes *what kind of work* gets done — not
 
 ### Provider assignment
 
-Agent types are backed by **LLM providers** (the AI tools that do the work — Claude Code, Gemini CLI, etc.). The mapping lives in [`agents.yml`](../agents.yml):
+Agent types are backed by **LLM providers** (the AI tools that do the work — Claude Code, Antigravity CLI, etc.). The mapping lives in [`agents.yml`](../agents.yml):
 
 ```yaml
-# Default: Claude builds, Gemini validates
+# Default: Claude builds, Antigravity validates
 assignments:
   default:
     builder: claude-code
-    validator: gemini-cli
+    validator: antigravity-cli
 ```
 
 If a provider isn't available, the system falls back — even running both types on the same provider in **isolated sessions** so they can't share context. Not as good as two different models, but significantly better than one session doing both.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -7,7 +7,7 @@ Set up this system in your project. You can adopt the full [pipeline](glossary.m
 ## Prerequisites
 
 - A GitHub repository
-- At least one AI tool (Claude Code, Gemini CLI, Cursor, ChatGPT, etc.)
+- At least one AI tool (Claude Code, Antigravity CLI, Cursor, ChatGPT, etc.)
 - Familiarity with the [key concepts](concepts.md)
 
 ---
@@ -148,13 +148,13 @@ Split [builder and validator](glossary.md) across different LLM providers for ge
 
 ### 1. Configure agents.yml
 
-The default [`agents.yml`](../agents.yml) maps Claude Code as builder, Gemini CLI as validator. Adjust for your providers:
+The default [`agents.yml`](../agents.yml) maps Claude Code as builder, Antigravity CLI as validator. Adjust for your providers:
 
 ```yaml
 assignments:
   default:
-    builder: claude-code      # Your primary coding AI
-    validator: gemini-cli     # Your review/audit AI
+    builder: claude-code         # Your primary coding AI
+    validator: antigravity-cli   # Your review/audit AI
 ```
 
 ### 2. Add validator agent config
@@ -178,7 +178,7 @@ The [manifest](glossary.md) already does this — each role has an `agent:` fiel
 ```yaml
 roles:
   - id: security-engineer
-    agent: validator        # Runs on the validator (Gemini)
+    agent: validator        # Runs on the validator (Antigravity)
   - id: software-engineer
     agent: builder          # Runs on the builder (Claude)
 ```


### PR DESCRIPTION
## Summary

Migrates all Gemini CLI references in the directives framework to Antigravity CLI (`agy`), per the migration plan in #30.

## Changes

| File | Change |
|------|--------|
| `agents.yml` | Provider id `gemini-cli` → `antigravity-cli`, name `Gemini CLI` → `Antigravity CLI`, binary `gemini` → `agy` |
| `docs/concepts.md` | Updated provider example and YAML comment |
| `docs/getting-started.md` | Updated CLI name in prereqs, config examples, and inline comments |

## What was kept

- `GEMINI.md` filename preserved throughout — Antigravity CLI natively reads it, no rename needed.
- `framework/reasoning-framework.md` — only references `GEMINI.md` as a filename, no CLI-specific language.
- `framework/agent-architecture.md` — already provider-agnostic, no changes needed.

## Part of
- Closes #31
- Parent: #30 (Phase 2 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)